### PR TITLE
German materials

### DIFF
--- a/crawl-ref/source/dat/strings/de/adjectives-e.txt
+++ b/crawl-ref/source/dat/strings/de/adjectives-e.txt
@@ -450,119 +450,24 @@
 ################################
 # materials
 ################################
-# mostly for rings/amulets, but a few are for armour/weapons as well/instead
-# these are also just cosmetic
-%%%%
-"amber "
-"Bernstein-"
-%%%%
-"brass "
-"Messing-"
-%%%%
-"bronze "
-"Bronze-"
-%%%%
-"copper "
-"Kupfer-"
+
+# used for randart weapons
+# (also used for jewellery, and in some cases, potion or rune, but we've given specific translations for those)
 %%%%
 "crystal "
 "Kristall-"
 %%%%
-"diamond "
-"Diamant-"
-%%%%
-"ebony "
-"Ebenholz-"
-%%%%
-"garnet "
-"Granat-"
-%%%%
-"glass "
-"Glas-"
-%%%%
-"granite "
-"Granit-"
-%%%%
 "ivory "
 "Elfenbein-"
-%%%%
-"jade "
-"Jade-"
-%%%%
-# "lapis lazuli" will be split into two words
-"lapis "
-"Lapis"
-%%%%
-"lazuli "
-"lazuli-"
-%%%%
-"lead "
-"Blei-"
-%%%%
-"marble "
-"Marmor-"
-%%%%
-"pearl "
-"Perlen-"
-%%%%
-"pewter "
-"Zinn-"
-%%%%
-"platinum "
-"Platin-"
-%%%%
-"silken "
-"Seide-"
-%%%%
-"steel "
-"Stahl-"
-%%%%
-"tin "
-"Zinn-"
-%%%%
-"turquoise "
-"Türkis-"
-%%%%
-"wooden "
-"Holz-"
-%%%%
-"zirconium "
-"Zirkonium-"
-%%%%
-
-# these ones are a jewellery material and a rune
-%%%%
-"gossamer "
-"hauchdünne "
 %%%%
 "bone "
 "knöcherne "
 %%%%
-"iron "
-"eiserne "
-%%%%
-"silver "
-"silberne "
-%%%%
-# used for potion colour, jewellery material, and rune
-"golden "
-"goldene "
-%%%%
-
-# These ones are a jewellery material, and also a potion colour
-# so we have to distinguish them
-%%%%
-"amethyst "
-"Amethyst-"
-%%%%
-"emerald "
-"Smaragd-"
-%%%%
-"ruby "
-"Rubin-"
-%%%%
 "sapphire "
 "Saphir-"
+%%%%
+"ebony "
+"Ebenholz-"
 %%%%
 
 ################################
@@ -660,6 +565,15 @@
 #"saphirblaue "
 %%%%
 
+# used to mean both metal and colour
+%%%%
+"silver "
+"silberne "
+%%%%
+"golden "
+"goldene "
+%%%%
+
 ################################
 # potions
 ################################
@@ -703,42 +617,6 @@
 "slimy "
 "schleimige "
 %%%%
-
-################################
-# runes
-################################
-# Not really used because we have defined the entire strings (e.g. "the golden rune")
-# There are 17 runes in total.
-# 2 (glowing, sepentine) covered under general adjectives
-# 5 (gossamer, bone, iron, silver, golden) covered in materials section
-# 1 (dark) covered under colours
-# 1 (slimy) covered under potions
-# 8 covered here
-
-%%%%
-"decaying "
-"verwesende "
-%%%%
-"barnacled "
-"seepockenbefallene "
-%%%%
-"abyssal "
-"abgründige "
-%%%%
-"icy "
-"eisige "
-%%%%
-"demonic "
-"dämonische "
-%%%%
-"magical "
-"magische "
-%%%%
-"fiery "
-"feurige "
-%%%%
-"obsidian "
-"vulkanische "
 
 ################################
 # doors/gates

--- a/crawl-ref/source/dat/strings/de/items-singular-def-nom.txt
+++ b/crawl-ref/source/dat/strings/de/items-singular-def-nom.txt
@@ -319,60 +319,40 @@ die {adj-en}%sGolddrachenschuppen
 # Rings
 #################################
 
+# general catch-all
 %%%%
 the %sring
 der {adj-e}%sRing
 %%%%
 
-# unidentified
-%%%%
-the %swooden ring
-der {adj-e}%sHolzring
-%%%%
-the %ssilver ring
-der {adj-e}%sSilberring
-%%%%
-the %sgolden ring
-der {adj-e}%sGoldring
-%%%%
-the %siron ring
-der {adj-e}%sEisenring
-%%%%
-the %ssteel ring
-der {adj-e}%sStahlring
-%%%%
-the %stourmaline ring
-der {adj-e}%sTurmalinring
-%%%%
-the %sbrass ring
-der {adj-e}%sMessingring
-%%%%
-the %scopper ring
-der {adj-e}%sKupferring
-%%%%
-the %sgranite ring
-der {adj-e}%sGranitring
-%%%%
-the %sivory ring
-der {adj-e}%sElfenbeinring
-%%%%
-the %sruby ring
-der {adj-e}%sRubinring
-%%%%
-the %smarble ring
-der {adj-e}%sMarmorring
-%%%%
-the %sjade ring
-der {adj-e}%sJadering
-%%%%
-the %sglass ring
-der {adj-e}%sGlasring
+# unidentified rings have two adjectives
+# the one closest to the noun is a material, which in German is usually combined with the noun
+
+# this is combined list from item-name.cc and descript/randname.txt
 %%%%
 the %sagate ring
 der {adj-e}%sAchatring
 %%%%
+the %samber ring
+der {adj-e}%sBernsteinring
+%%%%
 the %sbone ring
 der {adj-e}%sKnochenring
+%%%%
+the %sbrass ring
+der {adj-e}%sMessingring
+%%%%
+the %sbronze ring
+der {adj-e}%sBronzering
+%%%%
+the %scabochon ring
+der {adj-e}%sCabochonring
+%%%%
+the %scopper ring
+der {adj-e}%sKupferring
+%%%%
+the %scoral ring
+der {adj-e}%sKorallenring
 %%%%
 the %sdiamond ring
 der {adj-e}%sDiamantring
@@ -380,11 +360,47 @@ der {adj-e}%sDiamantring
 the %semerald ring
 der {adj-e}%sSmaragdring
 %%%%
-the %speridot ring
-der {adj-e}%sPeridotring
-%%%%
 the %sgarnet ring
 der {adj-e}%sGranatring
+%%%%
+the %sgilded ring
+der {adj-e}%svergoldete Ring
+%%%%
+the %sglass ring
+der {adj-e}%sGlasring
+%%%%
+the %sgossamer ring
+der {adj-e}%sSpinnfadenring
+%%%%
+the %sgolden ring
+der {adj-e}%sGoldring
+%%%%
+the %sgranite ring
+der {adj-e}%sGranitring
+%%%%
+the %siron ring
+der {adj-e}%sEisenring
+%%%%
+the %sivory ring
+der {adj-e}%sElfenbeinring
+%%%%
+the %sjade ring
+der {adj-e}%sJadering
+%%%%
+the %slapis lazuli ring
+der {adj-e}%sLapislazuliring
+%%%%
+the %slead ring
+der {adj-e}%sBleiring
+%%%%
+the %smarble ring
+der {adj-e}%sMarmorring
+%%%%
+the %smoonstone ring
+der {adj-e}%sMondsteinring
+%%%%
+the %sonyx ring
+der {adj-e}%sOnyxring
 %%%%
 the %sopal ring
 der {adj-e}%sOpalring
@@ -392,38 +408,54 @@ der {adj-e}%sOpalring
 the %spearl ring
 der {adj-e}%sPerlenring
 %%%%
-the %scoral ring
-der {adj-e}%sKorallenring
+the %speridot ring
+der {adj-e}%sPeridotring
+%%%%
+the %spewter ring
+der {adj-e}%sHartzinnring
+%%%%
+the %splatinum ring
+der {adj-e}%sPlatinring
+%%%%
+the %sruby ring
+der {adj-e}%sRubinring
 %%%%
 the %ssapphire ring
 der {adj-e}%sSaphirring
 %%%%
-the %scabochon ring
-der {adj-e}%sCabochonring
+the %ssilver ring
+der {adj-e}%sSilberring
 %%%%
-the %sgilded ring
-der {adj-e}%svergoldete Ring
+the %ssteel ring
+der {adj-e}%sStahlring
 %%%%
-the %sonyx ring
-der {adj-e}%sOnyxring
+the %stin ring
+der {adj-e}%sZinnring
 %%%%
-the %sbronze ring
-der {adj-e}%sBronzering
+the %stourmaline ring
+der {adj-e}%sTurmalinring
 %%%%
-the %smoonstone ring
-der {adj-e}%sMondsteinring
+the %sturquoise ring
+der {adj-e}%sTürkisring
+%%%%
+the %swooden ring
+der {adj-e}%sHolzring
 %%%%
 
 #################################
 # Amulets
 #################################
 
+# general catch-all
 %%%%
 the %samulet
 das {adj-e}%sAmulett
 %%%%
 
-# unidentified
+# unidentified amulets have two adjectives
+# the one closest to the noun is (usually) a material, which in German is usually combined with the noun
+
+# from item-name.txt
 %%%%
 the %ssapphire amulet
 das {adj-e}%sSaphiramulett
@@ -504,13 +536,37 @@ the %ssoapstone amulet
 das {adj-e}%sSpecksteinamulett
 %%%%
 the %slapis lazuli amulet
-das {adj-e}%sLapislazuli-Amulett
+das {adj-e}%sLapislazuliamulett
 %%%%
 the %sfiligree amulet
 das {adj-e}%sFiligranamulett
 %%%%
 the %sberyl amulet
 das {adj-e}%sBeryllamulett
+%%%%
+
+# extras from database/randname.txt
+%%%%
+the %scrystal amulet
+das {adj-e}%sKristallamulett
+%%%%
+the %sgraven amulet
+das {adj-e}%sgravierte amulett
+%%%%
+the %siron amulet
+das {adj-e}%sEisenamulett
+%%%%
+the %sivory amulet
+das {adj-e}%sElfenbeinamulett
+%%%%
+the %slead amulet
+das {adj-e}%sBleiamulett
+%%%%
+the %spewter amulet
+das {adj-e}%sHartzinnamulett
+%%%%
+the %stin amulet
+das {adj-e}%sZinnamulett
 %%%%
 
 #################################
@@ -740,6 +796,9 @@ der {adj-e}%srubinrote Zaubertrank
 %%%%
 the %ssapphire potion
 der {adj-e}%ssaphirblaue Zaubertrank
+%%%%
+the %sgolden potion
+der {adj-e}%sgoldene Zaubertrank
 %%%%
 
 #################################

--- a/crawl-ref/source/dat/strings/de/items-uninflected.txt
+++ b/crawl-ref/source/dat/strings/de/items-uninflected.txt
@@ -150,22 +150,22 @@ Geschoss
 
 %%%%
 decaying
-verfallende
+verwesende
 %%%%
 barnacled
-Kletten-
+seepockenbefallene
 %%%%
 gossamer
-Spinnfäden-
+Spinnfaden
 %%%%
 serpentine
-Schlangen-
+Schlangen
 %%%%
 slimy
 schleimige
 %%%%
 abyssal
-Abgrunds-
+Abgrunds
 %%%%
 # duplicate of missile brand
 #silver
@@ -178,13 +178,13 @@ goldene
 # hell runes
 %%%%
 obsidian
-Obsidian-
+Obsidian
 %%%%
 icy
 eisige
 %%%%
 bone
-Knochen-
+Knochen
 %%%%
 iron
 eiserne


### PR DESCRIPTION
Give specific translations for material + ring/amulet.
This gets rid of most of the hyphens (although not quite all).