### PR TITLE
German: Unique monsters, Prince Ribbit --> Prinz Quak

### DIFF
--- a/crawl-ref/source/dat/strings/de/monsters-unique-def.txt
+++ b/crawl-ref/source/dat/strings/de/monsters-unique-def.txt
@@ -267,7 +267,7 @@ the Ereshkigal
 die Ereshkigal
 %%%%
 the Prince Ribbit
-der Prinz Ribbit
+der Prinz Quak
 %%%%
 the Crazy Yiuf
 der Verrückte Yiuf

--- a/crawl-ref/source/dat/strings/de/monsters-unique-poss.txt
+++ b/crawl-ref/source/dat/strings/de/monsters-unique-poss.txt
@@ -222,7 +222,7 @@ Ereshkigal's
 von Ereshkigal
 %%%%
 Prince Ribbit's
-von Prinz Ribbit
+von Prinz Quak
 %%%%
 Crazy Yiuf's
 vom Verrückten Yiuf

--- a/crawl-ref/source/test/i18n/de/mon-test.cc
+++ b/crawl-ref/source/test/i18n/de/mon-test.cc
@@ -160,15 +160,15 @@ int main()
     cout << endl;
 
     // unique with weak declension
-    test("Prinz Ribbit", "Prince Ribbit");
-    test("der hilflose Prinz Ribbit", "the helpless Prince Ribbit");
-    test("hilfloser Prinz Ribbit", "helpless Prince Ribbit");
-    test("Du triffst Prinzen Ribbit", "You hit %s", "Prince Ribbit");
-    test("Du triffst den hilflosen Prinzen Ribbit", "You hit %s", "the helpless Prince Ribbit");
-    test("Du kollidierst mit Prinzen Ribbit!", "You collide with %s!", "Prince Ribbit");
-    test("Du kollidierst mit dem hilflosen Prinzen Ribbit!", "You collide with %s!", "the helpless Prince Ribbit");
-    test("Du blockst den Angriff von Prinz Ribbit.", "You block %s attack.", "Prince Ribbit's");
-    test("Die Wunden von Prinz Ribbit heilen von selbst!", "%s's wounds heal themselves!", "Prince Ribbit");
+    test("Prinz Quak", "Prince Ribbit");
+    test("der hilflose Prinz Quak", "the helpless Prince Ribbit");
+    test("hilfloser Prinz Quak", "helpless Prince Ribbit");
+    test("Du triffst Prinz Quak", "You hit %s", "Prince Ribbit");
+    test("Du triffst den hilflosen Prinz Quak", "You hit %s", "the helpless Prince Ribbit");
+    test("Du kollidierst mit Prinz Quak!", "You collide with %s!", "Prince Ribbit");
+    test("Du kollidierst mit dem hilflosen Prinz Quak!", "You collide with %s!", "the helpless Prince Ribbit");
+    test("Du blockst den Angriff von Prinz Quak.", "You block %s attack.", "Prince Ribbit's");
+    test("Die Wunden von Prinz Quak heilen von selbst!", "%s's wounds heal themselves!", "Prince Ribbit");
     cout << endl;
 
     // unique with a capitalised adjective in the name


### PR DESCRIPTION
Unique monsters don't really need corrections. I think Ribbit should be translated so Germans who don't speak English get the pun.