### PR TITLE
German: Use Odem for breath that has an effect

### DIFF
--- a/crawl-ref/source/dat/descript/de/monsters.txt
+++ b/crawl-ref/source/dat/descript/de/monsters.txt
@@ -757,7 +757,7 @@ bone dragon
 
 Eine mächtige untote Abscheulichkeit, die mithilfe mächtiger nekromantischer
 Magie aus den gebrochenen Knochen vieler Drachen zusammengesetzt wurde.
-Glücklicherweise ging dabei das Organ verloren, das den furchterregenden Atem
+Glücklicherweise ging dabei das Organ verloren, das den furchterregenden Odem
 eines Drachens erzeugt.
 %%%%
 boulder beetle
@@ -833,7 +833,7 @@ catoblepas
 
 Ein träger schwarzer Büffel, dessen Haut mit stumpfen Schuppen überzogen ist.
 Seinen schweineartigen Kopf hält er knapp über dem Boden, geschützt durch eine
-steife Mähne aus Borsten. Sein furchterregender Atem verwandelt Fleisch in
+steife Mähne aus Borsten. Sein furchterregender Odem verwandelt Fleisch in
 Stein.
 %%%%
 caustic shrike
@@ -1062,7 +1062,7 @@ Kreaturen des Albtraums auf die Fährte seines Opfers zu hetzen.
 draconian
 
 Ein Humanoid mit braunen Schuppen, einem Reptilienschwanz und kleinen Flügeln.
-Die ausgeprägte Färbung und der kräftige Atem seiner erwachsenen Form müssen
+Die ausgeprägte Färbung und der kräftige Odem seiner erwachsenen Form müssen
 noch entwickelt werden.
 %%%%
 draconian annihilator
@@ -1451,7 +1451,7 @@ macht.
 %%%%
 hell hog
 
-Ein extrem großes und aggressives Schwein, in der Hölle gezüchtet, dessen Atem
+Ein extrem großes und aggressives Schwein, in der Hölle gezüchtet, dessen Odem
 seine Feinde zu Asche verbrennt.
 %%%%
 hell hound
@@ -2049,7 +2049,7 @@ Rechtsprechung.
 %%%%
 pearl dragon
 
-Ein Drache, der den heiligen göttlichen Kräften geweiht ist. Sein Atem ist
+Ein Drache, der den heiligen göttlichen Kräften geweiht ist. Sein Odem ist
 gesegnetes Feuer und seine Klauen versengen seine Opfer mit göttlichem Zorn.
 %%%%
 phantasmal warrior
@@ -2188,7 +2188,7 @@ geisterhaften Flammen.
 %%%%
 rime drake
 
-Ein kleiner, aber gefährlicher Drache. Sein Atem ist selbst an den wärmsten
+Ein kleiner, aber gefährlicher Drache. Sein Odem ist selbst an den wärmsten
 Tagen sichtbar.
 %%%%
 river rat
@@ -2285,7 +2285,7 @@ Dunkelheit unterscheiden lässt. Sie verwebt die Schatten zu mächtigen Dienern.
 %%%%
 shadow dragon
 
-Ein großer Schattendrache, der Böses und Tod ausstrahlt. Sein Atem stinkt nach
+Ein großer Schattendrache, der Böses und Tod ausstrahlt. Sein Odem stinkt nach
 dem Grab.
 %%%%
 shadow imp
@@ -2734,7 +2734,7 @@ Gesellschaft von Orks aufhält.
 %%%%
 war gargoyle
 Eine seltene Art von Gargoyle, der aus einer Statue aus massivem Stahl gefertigt
-und mit bösartiger Stärke, Geschwindigkeit und waffenfähigem Atem ausgestattet
+und mit bösartiger Stärke, Geschwindigkeit und waffenfähigem Odem ausgestattet
 ist.
 %%%%
 warmonger

--- a/crawl-ref/source/dat/descript/de/status.txt
+++ b/crawl-ref/source/dat/descript/de/status.txt
@@ -98,7 +98,7 @@ allmählich, wenn du Erfahrung sammelst.
 %%%%
 Breath status
 
-Dich stockt der Atem, und du kannst deine angeborene Atemfähigkeit nicht nutzen,
+Dich stockt der Atem, und du kannst deine angeborene Odemfähigkeit nicht nutzen,
 bis der Status abläuft.
 %%%%
 Exh status
@@ -503,7 +503,7 @@ Dragon status
     if you.race():find("Draconian") then
         desc = desc .. " Drache verwandelt"
         if you.race() ~= "Grey Draconian" then
-            desc = desc .. ", was die Kraft aller angeborenen Atemangriffe " ..
+            desc = desc .. ", was die Kraft aller angeborenen Odemangriffe " ..
                            "erhöht"
         end
         if you.race() == "Red Draconian" then

--- a/crawl-ref/source/dat/descript/de/status.txt
+++ b/crawl-ref/source/dat/descript/de/status.txt
@@ -98,7 +98,7 @@ allmählich, wenn du Erfahrung sammelst.
 %%%%
 Breath status
 
-Dir stockt der Atem, und du kannst deine angeborene Odemfähigkeit nicht nutzen,
+Dir stockt der Atem und du kannst deine angeborene Odemfähigkeit nicht nutzen,
 bis der Status abläuft.
 %%%%
 Exh status

--- a/crawl-ref/source/dat/descript/de/status.txt
+++ b/crawl-ref/source/dat/descript/de/status.txt
@@ -98,7 +98,7 @@ allmählich, wenn du Erfahrung sammelst.
 %%%%
 Breath status
 
-Dich stockt der Atem, und du kannst deine angeborene Odemfähigkeit nicht nutzen,
+Dir stockt der Atem, und du kannst deine angeborene Odemfähigkeit nicht nutzen,
 bis der Status abläuft.
 %%%%
 Exh status

--- a/crawl-ref/source/dat/strings/de/beams.txt
+++ b/crawl-ref/source/dat/strings/de/beams.txt
@@ -145,10 +145,10 @@ the splash of poison
 der Giftspritzer
 %%%%
 the fiery breath
-der feurige Atem
+der feurige Odem
 %%%%
 the freezing breath
-der eisige Atem
+der eisige Odem
 %%%%
 the glob of acid
 der Säureklumpen
@@ -248,7 +248,7 @@ the mystic blast
 die mystische Druckwelle
 %%%%
 the chilling breath
-der kühlende Atem
+der kühlende Odem
 %%%%
 the porkalator
 die Schweinifizierung
@@ -502,10 +502,10 @@ a splash of poison
 ein Giftspritzer
 %%%%
 a fiery breath
-ein feuriger Atem
+ein feuriger Odem
 %%%%
 a freezing breath
-ein eisiger Atem
+ein eisiger Odem
 %%%%
 a glob of acid
 ein Säureklumpen
@@ -605,7 +605,7 @@ a mystic blast
 eine mystische Druckwelle
 %%%%
 a chilling breath
-ein kühlender Atem
+ein kühlender Odem
 %%%%
 a porkalator
 eine Schweinifizierung
@@ -856,10 +856,10 @@ splash of poison
 Giftspritzer
 %%%%
 fiery breath
-feuriger Atem
+feuriger Odem
 %%%%
 freezing breath
-eisiger Atem
+eisiger Odem
 %%%%
 glob of acid
 Säureklumpen
@@ -961,7 +961,7 @@ mystic blast
 mystische Druckwelle
 %%%%
 chilling breath
-kühlender Atem
+kühlender Odem
 %%%%
 porkalator
 Schweinifizierung
@@ -1306,7 +1306,7 @@ tukima's dance
 Tukimas Tanz
 %%%%
 breath of the dead
-Atem der Toten
+Odem der Toten
 %%%%
 # duplicate of status
 #resistance

--- a/crawl-ref/source/dat/strings/de/messages.txt
+++ b/crawl-ref/source/dat/strings/de/messages.txt
@@ -3316,7 +3316,7 @@ it flies swiftly and unpredictably
 es fliegt schnell und unberechenbar
 %%%%
 it's breath smoulders ominously
-sein Atem riecht unheilvoll
+sein Odem glimmt bedrohlich
 %%%%
 it is covered with eyes and tentacles
 es ist mit Augen und Tentakeln bedeckt

--- a/crawl-ref/source/dat/strings/de/statuses.txt
+++ b/crawl-ref/source/dat/strings/de/statuses.txt
@@ -753,7 +753,7 @@ short of breath
 kurzatmig
 %%%%
 breath weapon
-Atem-Waffe
+Odemwaffe
 %%%%
 You are short of breath.
 Du bist kurzatmig.


### PR DESCRIPTION
Use Odem instead of Atem for breath that has an effect.

Odem was already used in some places:
dat/strings/de/spells.txt:Versengender Odem
dat/strings/de/spells.txt:Kühler Odem
dat/strings/de/spells.txt:Heiliger Odem
dat/strings/de/spells.txt:Odem der Höllenschlange von Gehenna
dat/strings/de/spells.txt:Odem der Höllenschlange von Kokytus
dat/strings/de/spells.txt:Odem der Höllenschlange von Dis
dat/strings/de/spells.txt:Odem der Höllenschlange von Tartarus

I've left some instances of Atem:
dat/descript/de/monsters.txt:ihnen so Atem und Stimme rauben.
dat/descript/de/quotes.txt:„Na, in unserem Land,“ sagte Alice, noch ein bißchen außer Atem, „kommt man
dat/descript/de/status.txt:Dich stockt der Atem, und du kannst deine angeborene Odemfähigkeit nicht nutzen,
dat/strings/de/abilities.txt:Atem *(This is an ability cost)*
dat/strings/de/messages.txt:Zwischen den Einsätzen dieser Fähigkeit musst du zu Atem kommen.
dat/strings/de/monster-props.txt:Atem anhaltend
dat/strings/de/monster-props.txt:Atem anhaltend
dat/strings/de/statuses.txt:Du hast deinen Atem zurückbekommen.
