### PR TITLE
German: Correct montitle.txt

### DIFF
--- a/crawl-ref/source/dat/database/de/montitle.txt
+++ b/crawl-ref/source/dat/database/de/montitle.txt
@@ -9,7 +9,7 @@ Agnes die Wandererin
 %%%%
 Aizul title
 
-Aizul der Vernachlässigende Wächter
+Aizul der Unzuverlässige Wächter
 %%%%
 Antaeus title
 
@@ -37,11 +37,11 @@ Bai Suzhen, Madame Weißschlange
 %%%%
 Boris title
 
-Boris, Meister von Leben und Tod
+Boris, Meister über Leben und Tod
 %%%%
 Cerebov title
 
-Cerebov, Dämonenfürst von Feuer und Stahl
+Cerebov, Dämonenfürst des Feuers und des Stahls
 %%%%
 Chuck title
 
@@ -49,7 +49,7 @@ Chuck der Sammler
 %%%%
 Crazy Yiuf title
 
-Verrückte Yiuf der Erleuchtete
+Verrückter Yiuf der Erleuchtete
 %%%%
 Dispater title
 
@@ -65,7 +65,7 @@ Donald der Abenteurer
 %%%%
 Dowan title
 
-Dowan, Brüder von Duvessa
+Dowan, Bruder von Duvessa
 %%%%
 Duvessa title
 
@@ -81,7 +81,7 @@ Ereshkigal, Königin von Tartarus
 %%%%
 Erica title
 
-Erica des hitzigen Gemüts
+Erica mit dem Feurigen Temperament
 %%%%
 Erolcha title
 
@@ -89,24 +89,24 @@ Erolcha die Listige
 %%%%
 Eustachio title
 
-Eustachio der Prachtvolle
+Eustachio der Großartige
 %%%%
 Fannar title
 
 # neuter
-Fannar das Kaltherzige
+Fannar mit dem Kalten Herz
 %%%%
 Frances title
 
-Frances, Herzogin von Pandemonium
+Frances, Herzogin des Pandämoniums
 %%%%
 Frederick title
 
-Frederick der Makellos
+Frederick der Makellose
 %%%%
 Gastronok title
 
-Gastronok der Schwerfällig
+Gastronok der Schwerfällige
 %%%%
 Geryon title
 
@@ -122,11 +122,11 @@ Grum der Jäger
 %%%%
 Harold title
 
-Harold der Verwitterte
+Harold der Wettergegerbte
 %%%%
 Ignacio title
 
-Ignacio, Meister der Quälenden Schmerzen
+Ignacio, Meister der Unerträglichen Schmerzen
 %%%%
 Ilsuiw title
 
@@ -134,11 +134,11 @@ Ilsuiw, Hexe der Gezeiten
 %%%%
 Ijyb title
 
-Ijyb der Verdorbene Goblin
+Ijyb die Verdrehte
 %%%%
 Jessica title
 
-Jessica die Zauberlehrlingin
+Jessica die Zauberanfängerin
 %%%%
 Jorgrun title
 
@@ -170,7 +170,7 @@ Lom Lobon, Dämonenfürst des verbotenen Wissens
 %%%%
 Louise title
 
-Louise die Verdorbenen
+Louise die Verdorbene
 %%%%
 Maggie title
 
@@ -190,7 +190,7 @@ Maurice der Dieb
 %%%%
 Menkaure title
 
-Menkaure, Staubprinz
+Menkaure, Prinz des Staubes
 %%%%
 Mennas title
 
@@ -207,7 +207,7 @@ Murray der Dämonische Sprechende Schädel
 # NOTE: Title deliberately similar to Boris'
 Natasha title
 
-Natasha, Diener von Leben und Tod
+Natasha, Dienerin von Leben und Tod
 %%%%
 Nellie title
 
@@ -219,7 +219,7 @@ Nergalle die Seelenbinderin
 %%%%
 Nessos title
 
-Nessos der Zentaur-Schütze
+Nessos der Zentaurenschütze
 %%%%
 Nikola title
 
@@ -243,7 +243,7 @@ Purgy der Sanftmütige
 %%%%
 Robin title
 
-Robin des starken Arms
+Robin mit dem Starken Arm
 %%%%
 Roxanne title
 
@@ -263,7 +263,7 @@ Sigmund der Gefürchtete
 %%%%
 Snorg title
 
-Snorg der Unersättliche
+Snorg die Unersättliche
 %%%%
 Sojobo title
 
@@ -279,7 +279,7 @@ Terence der Unvorsichtige
 %%%%
 Tiamat title
 
-Tiamat, Avatar des Drachenfürstin
+Tiamat, Avatar der Drachenfürstin
 %%%%
 Urug title
 
@@ -287,9 +287,9 @@ Urug die Orkische Ballista
 %%%%
 Vashnia title
 
-Vashnia die Elite Naga-Schützin
+Vashnia die Elite-Nagaschützin
 %%%%
 Xtahua title
 
-Xtahua der Uralte
+Xtahua die Uralte
 %%%%

--- a/crawl-ref/source/dat/database/de/montitle.txt
+++ b/crawl-ref/source/dat/database/de/montitle.txt
@@ -291,5 +291,5 @@ Vashnia die Elite-Nagaschützin
 %%%%
 Xtahua title
 
-Xtahua die Uralte
+Xtahua der Uralte Drache
 %%%%


### PR DESCRIPTION
Minor gender problems here. Ijyb is female, but there's no German word for a female goblin. Xtahua is gender neutral, but "das Uralte" sounds incomplete and "der Uralte" sounds 100% male.