### PR TITLE
German: Fix "level of <branch>"

### DIFF
--- a/crawl-ref/source/dat/strings/de/dungeon.txt
+++ b/crawl-ref/source/dat/strings/de/dungeon.txt
@@ -263,6 +263,113 @@ the Desolation of Salt
 %%%%
 
 ##############################################
+# Long branch names (genitive)
+##############################################
+%%%%
+{gen}the Dungeon
+{m}des Kerkers
+%%%%
+{gen}the Ecumenical Temple
+{m}des Ökumenischen Tempels
+%%%%
+{gen}the Orcish Mines
+{pl}der orkischen Minen
+%%%%
+{gen}the Elven Halls
+{pl}der Elfenhallen
+%%%%
+{gen}the Lair of Beasts
+{f}der Höhle der Bestien
+%%%%
+{gen}the Swamp
+{m}des Sumpfes
+%%%%
+{gen}the Shoals
+{pl}der Untiefen
+%%%%
+{gen}the Snake Pit
+{f}der Schlangengrube
+%%%%
+{gen}the Spider Nest
+{n}des Spinnennests
+%%%%
+{gen}the Pits of Slime
+{pl}der Schleimgruben
+%%%%
+{gen}the Vaults
+{pl}der Gewölbe
+%%%%
+{gen}the Crypt
+{f}der Krypta
+%%%%
+{gen}the Tomb of the Ancients
+{n}des Grabes der Uralten
+%%%%
+{gen}the Depths
+{pl}der Tiefen
+%%%%
+{gen}the Hells
+{pl}der Höllen
+%%%%
+{gen}the Vestibule of Hell
+{n}des Vestibüls der Hölle
+%%%%
+{gen}the Iron City of Dis
+{f}der Eisernen Stadt von Dis
+%%%%
+{gen}Gehenna
+von Gehenna
+%%%%
+{gen}Cocytus
+von Kokytus
+%%%%
+{gen}Tartarus
+von Tartarus
+%%%%
+{gen}the Realm of Zot
+{n}des Reiches von Zot
+%%%%
+{gen}the Abyss
+{m}des Abgrunds
+%%%%
+{gen}Pandemonium
+von Pandämonium
+%%%%
+{gen}a ziggurat
+{f}einer Zikkurat
+%%%%
+{gen}a bazaar
+{m}eines Basars
+%%%%
+{gen}a treasure trove
+{f}einer Schatzkammer
+%%%%
+{gen}a sewer
+{m}eines Kanals
+%%%%
+{gen}an ossuary
+{n}eines Beinhauses
+%%%%
+{gen}a bailey
+{m}eines Burghofs
+%%%%
+{gen}a Gauntlet
+{m}eines Spießrutenlaufs
+%%%%
+{gen}an ice cave
+{f}einer Eishöhle
+%%%%
+{gen}a volcano
+{m}eines Vulkans
+%%%%
+{gen}a wizard's laboratory
+{n}des Labors eines Zauberers
+%%%%
+{gen}the Desolation of Salt
+{f}der Trostlosigkeit des Salzes
+%%%%
+
+##############################################
 # Branch abbreviations
 # These should be 8 characters or less.
 #

--- a/crawl-ref/source/dat/strings/de/messages.txt
+++ b/crawl-ref/source/dat/strings/de/messages.txt
@@ -3981,7 +3981,7 @@ There is no level below you in this branch.
 In diesem Zweig gibt es keine Ebene unter dir.
 %%%%
 "What level of %s? "
-Welche Ebene von {dat}%s?
+Welche Ebene {gen}%s?
 %%%%
 That's not a valid depth.
 Das ist keine gültige Tiefe.
@@ -5344,13 +5344,13 @@ You need at least %d gold to offer a bribe.
 Du brauchst mindestens %d Gold, um eine Bestechung anzubieten.
 %%%%
 You can't bribe the denizens of %s or the denizens of %s.
-Du kannst die Bewohner von {dat}%s oder von {dat}%s nicht bestechen.
+Du kannst die Bewohner {gen}%s oder {gen}%s nicht bestechen.
 %%%%
 You can't bribe the denizens of %s.
-Du kannst die Bewohner von {dat}%s nicht bestechen.
+Du kannst die Bewohner {gen}%s nicht bestechen.
 %%%%
 Do you want to bribe the denizens of %s?
-Willst du die Bewohner von {dat}%s bestechen?
+Willst du die Bewohner {gen}%s bestechen?
 %%%%
 # Gozag spreads your bribe to <branch>!
 Gozag spreads your bribe to %s!
@@ -17193,7 +17193,7 @@ Trotzdem dorthin reisen?
 "Zu welchem Altar gehen? (? - Hilfe) "
 %%%%
 "What level of %s? (default %s, ? - help) "
-"Welche Ebene von {dat}%s? (defaultmäßig %s, ? - Hilfe) "
+"Welche Ebene {gen}%s? (defaultmäßig %s, ? - Hilfe) "
 %%%%
 You're already at the bottom of this branch!
 Du bist schon am Ende dieses Zweigs!
@@ -17214,7 +17214,7 @@ Calm down first, please.
 Beruhige dich bitte zuerst.
 %%%%
 Level %d of %s
-Ebene %d von {dat}%s
+Ebene %d {gen}%s
 %%%%
 Existing waypoints:
 Bestehende Wegpunkte:

--- a/crawl-ref/source/dat/strings/dungeon.txt
+++ b/crawl-ref/source/dat/strings/dungeon.txt
@@ -263,6 +263,113 @@ the Desolation of Salt
 %%%%
 
 ##############################################
+# Long branch names (possessive)
+##############################################
+%%%%
+{poss}the Dungeon
+
+%%%%
+{poss}the Ecumenical Temple
+
+%%%%
+{poss}the Orcish Mines
+
+%%%%
+{poss}the Elven Halls
+
+%%%%
+{poss}the Lair of Beasts
+
+%%%%
+{poss}the Swamp
+
+%%%%
+{poss}the Shoals
+
+%%%%
+{poss}the Snake Pit
+
+%%%%
+{poss}the Spider Nest
+
+%%%%
+{poss}the Pits of Slime
+
+%%%%
+{poss}the Vaults
+
+%%%%
+{poss}the Crypt
+
+%%%%
+{poss}the Tomb of the Ancients
+
+%%%%
+{poss}the Depths
+
+%%%%
+{poss}the Hells
+
+%%%%
+{poss}the Vestibule of Hell
+
+%%%%
+{poss}the Iron City of Dis
+
+%%%%
+{poss}Gehenna
+
+%%%%
+{poss}Cocytus
+
+%%%%
+{poss}Tartarus
+
+%%%%
+{poss}the Realm of Zot
+
+%%%%
+{poss}the Abyss
+
+%%%%
+{poss}Pandemonium
+
+%%%%
+{poss}a ziggurat
+
+%%%%
+{poss}a bazaar
+
+%%%%
+{poss}a treasure trove
+
+%%%%
+{poss}a sewer
+
+%%%%
+{poss}an ossuary
+
+%%%%
+{poss}a bailey
+
+%%%%
+{poss}a Gauntlet
+
+%%%%
+{poss}an ice cave
+
+%%%%
+{poss}a volcano
+
+%%%%
+{poss}a wizard's laboratory
+
+%%%%
+{poss}the Desolation of Salt
+
+%%%%
+
+##############################################
 # Branch abbreviations
 # These should be 8 characters or less.
 #


### PR DESCRIPTION
When translating "level of <branch>", use the genitive instead of the equivalent of "of %s", because:
"von %s" -> "von der/den" is ok, but "von dem" should usually be "vom".