### PR TITLE
German: Fix clouds

### DIFF
--- a/crawl-ref/source/dat/strings/de/annotations.txt
+++ b/crawl-ref/source/dat/strings/de/annotations.txt
@@ -250,7 +250,7 @@ Akrobat
 # weapon brands
 %%%%
 flame
-Flamme
+Flammen
 %%%%
 freeze
 gefrieren

--- a/crawl-ref/source/dat/strings/de/hiscores.txt
+++ b/crawl-ref/source/dat/strings/de/hiscores.txt
@@ -346,7 +346,7 @@ Succumbed to %s %s
 {dat}%2$s {null}%1$s erlegen
 %%%%
 cloud of %s
-Wolke aus %s
+Wolke aus {dat}%s
 %%%%
 self
 sich selbst

--- a/crawl-ref/source/dat/strings/de/messages.txt
+++ b/crawl-ref/source/dat/strings/de/messages.txt
@@ -4309,7 +4309,7 @@ This square is bathed in translocational energy.
 Dieses Feld ist von Translokationsenergie durchdrungen.
 %%%%
 There is a cloud of %s here.
-Hier ist eine Wolke von {dat}%s.
+Hier ist eine Wolke aus {dat}%s.
 %%%%
 You see %s here.
 Du siehst {acc}%s hier.
@@ -11297,7 +11297,7 @@ Du hast {acc}%s verloren.
 %s rutscht weg, als du dich darauf zu bewegst!
 %%%%
 Really %s into that cloud of %s?
-Wirklich in die %2$s-Wolke {verb-inf}%1$s?
+Wirklich in die Wolke aus {dat}%2$s {verb-inf}%1$s?
 %%%%
 Do you really want to %s into the Zot trap?
 Willst du wirklich in die Zot-Falle {verb-inf}%s?
@@ -12051,7 +12051,7 @@ You cannot mutate at present.
 Du kannst zur Zeit nicht mutieren.
 %%%%
 Really become a tree while standing in a cloud of %s?
-Wirklich ein Baum werden, während du in einer Wolke von {dat}%s stehst?
+Wirklich ein Baum werden, während du in einer Wolke aus {dat}%s stehst?
 %%%%
 You feel woody for a moment.
 Du fühlst dich für einen Moment holzig.


### PR DESCRIPTION
Changed translation of "flame" to "Flammen"

Also translate "cloud of %s" as "Wolke aus {dat}%s".

It was previously inconsistent:
```
hiscores.txt:cloud of %s
hiscores.txt-Wolke aus %s
--
hiscores.txt:Engulfed by a cloud of %s
hiscores.txt-Verschlungen von einer Wolke aus {dat}%s
--
hiscores.txt:Engulfed by their own cloud of %s
hiscores.txt-Verschlungen von ihrer eigenen Wolke aus {dat}%s
--
messages.txt:A cloud of %s.
messages.txt-Eine Wolke aus {dat}%s.
--
messages.txt:There is a cloud of %s here.
messages.txt-Hier ist eine Wolke von {dat}%s.
--
messages.txt:You're standing in a cloud of %s!
messages.txt-Du stehst in einer Wolke aus {dat}%s!
--
messages.txt:Really %s into that cloud of %s?
messages.txt-Wirklich in die %2$s-Wolke {verb-inf}%1$s?
--
messages.txt:Really become a tree while standing in a cloud of %s?
messages.txt-Wirklich ein Baum werden, während du in einer Wolke von {dat}%s stehst?
--
messages.txt:You are standing in a cloud of %s! Ignite poison anyway?
messages.txt-Du stehst in einer Wolke aus {dat}%s! Trotzdem Gift entzünden?
```
